### PR TITLE
Adding an interrupt port at the sparc_nonblock.ac file.

### DIFF
--- a/sparc_block.ac
+++ b/sparc_block.ac
@@ -28,11 +28,7 @@ AC_ARCH(sparc){
   ac_icache   IC("2w", 128, 32, "wb", "fifo");
   ac_dcache   DC("2w", 512, 32, "wt", "fifo");
   
-
-
   ac_tlm2_intr_port intr_port;
-  
-
   ac_regbank RB:256;
   ac_regbank REGS:32;
 

--- a/sparc_nonblock.ac
+++ b/sparc_nonblock.ac
@@ -34,6 +34,7 @@ AC_ARCH(sparc){
   ac_regbank REGS:32;
 
   ac_reg npc;
+
   ac_tlm2_intr_port intr_port;
   
   ac_reg<1> PSR_icc_n;

--- a/sparc_nonblock.ac
+++ b/sparc_nonblock.ac
@@ -34,7 +34,8 @@ AC_ARCH(sparc){
   ac_regbank REGS:32;
 
   ac_reg npc;
-
+  ac_tlm2_intr_port intr_port;
+  
   ac_reg<1> PSR_icc_n;
   ac_reg<1> PSR_icc_z;
   ac_reg<1> PSR_icc_v;


### PR DESCRIPTION
When we use a processor model inside platforms, we usually need an interrupt port; so, we have included the TLM2 interrupt port at the sparc_nonblock.ac.
